### PR TITLE
Update README.md: Avoid confusion with official EIDF documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# EIDF Kubernetes Tutorial and Demos
+# Infk8s Kubernetes Tutorial and Demos
 
 Welcome to an in-depth look at working with Docker and Kubernetes as part of the EIDF GPU Cluster transition guide. This repository serves as a complement to our [YouTube tutorial](https://youtu.be/fzpPtnl7bn0), providing step-by-step walkthroughs for beginners and machine learning enthusiasts wanting to make the most of Docker and Kubernetes.
+
+**Please note that this Tutorial is specific to the `informatics` namespace on the EIDF cluster. It should not be used as guidance by other EIDF customers. The official EIDF userguide and documentation can be found [here](https://epcced.github.io/eidf-docs/services/gpuservice/).**
 
 ## Demos
 
@@ -15,11 +17,18 @@ The repository includes four in-depth demos:
 MIT License
 
 ## Useful Links
-- [Main Package Discussed-Kubejobs:](https://github.com/AntreasAntoniou/kubejobs)
-- [Slide content:](https://docs.google.com/presentation/d/1BD3q8QWwc_khZXPGWabftBD2VUlknRpegjfVN8FnpY8/edit?usp=sharing)
-- [Slack EIDF Group:](https://join.slack.com/t/eidf-epcc-cluster/shared_invite/zt-26ggossxy-49mCadF_oDh~GOAYILO~hw)
-- [EIDF Community Github:](https://github.com/uoe-eidf-cluster-users/eidf-epcc-cluster/)
+### Information provided by EIDF
 - [EIDF official docs:](https://epcced.github.io/eidf-docs/services/gpuservice/)
+- [EIDF Portal](https://portal.eidf.ac.uk/static/index.html)
+
+### Specific to Infk8s
+- [Slack Infk8s Group:](https://join.slack.com/t/eidf-epcc-cluster/shared_invite/zt-26ggossxy-49mCadF_oDh~GOAYILO~hw)
+- [Slide content:](https://docs.google.com/presentation/d/1BD3q8QWwc_khZXPGWabftBD2VUlknRpegjfVN8FnpY8/edit?usp=sharing)
+- [Infk8s Community Github:](https://github.com/uoe-eidf-cluster-users/eidf-epcc-cluster/)
+
+### Kubejobs
+- [Main Package Discussed-Kubejobs:](https://github.com/AntreasAntoniou/kubejobs)
+
+### Useful information on the web  
 - [A Github repo with helpful kubernetes workflow nuggets](https://github.com/BayesWatch/kubeproject/tree/main/tutorials/simple-tutorial)
 - [A recipe for achieving state-less, fault tolerant experimentation for smooth sailing](https://github.com/AntreasAntoniou/minimal-ml-template)
-- [EIDF Portal](https://portal.eidf.ac.uk/static/index.html)


### PR DESCRIPTION
EIDF has requested that we make it clear that this is not official EIDF documentation. I've replaced EIDF with Infk8s and sorted the link collection into "topical" groups. 